### PR TITLE
dev to slave

### DIFF
--- a/pyrogram/__init__.py
+++ b/pyrogram/__init__.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "2.1.27"
+__version__ = "2.1.28"
 __license__ = "GNU Lesser General Public License v3.0 (LGPL-3.0)"
 __copyright__ = "Copyright (C) 2017-present Dan <https://github.com/delivrance>"
 

--- a/pyrogram/methods/account/set_account_ttl.py
+++ b/pyrogram/methods/account/set_account_ttl.py
@@ -29,7 +29,7 @@ class SetAccountTTL:
 
         .. note::
 
-            Days should be in range 30-548
+            Days should be in range 30-730
 
         .. include:: /_includes/usable-by/users.rst
 
@@ -43,7 +43,7 @@ class SetAccountTTL:
         Example:
             .. code-block:: python
 
-                # Set ttl in days
+                # Set account ttl to 1 year
                 await app.set_account_ttl(365)
         """
         r = await self.invoke(

--- a/pyrogram/methods/messages/send_media_group.py
+++ b/pyrogram/methods/messages/send_media_group.py
@@ -445,7 +445,7 @@ class SendMediaGroup:
                 raw.types.InputSingleMedia(
                     media=media,
                     random_id=self.rnd_id(),
-                    **await self.parser.parse(i.caption, i.parse_mode)
+                    **await utils.parse_text_entities(self, i.caption, i.parse_mode, i.caption_entities)
                 )
             )
 

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -25,7 +25,7 @@ import pyrogram
 from pyrogram import raw, enums
 from pyrogram import types
 from pyrogram import utils
-from pyrogram.errors import ChannelPrivate, MessageIdsEmpty, PeerIdInvalid, ChannelPrivate, BotMethodInvalid, ChannelForumMissing
+from pyrogram.errors import ChannelPrivate, MessageIdsEmpty, PeerIdInvalid, ChannelForumMissing
 from pyrogram.parser import utils as parser_utils, Parser
 from ..object import Object
 from ..update import Update
@@ -4950,7 +4950,7 @@ class Message(Object, Update):
             message_id=self.id
         )
 
-    async def pay(self) -> bool:
+    async def pay(self) -> List[Union["types.Photo", "types.Video"]]:
         """Bound method *pay* of :obj:`~pyrogram.types.Message`.
 
         Use as a shortcut for:
@@ -4968,7 +4968,7 @@ class Message(Object, Update):
                 await message.pay()
 
         Returns:
-            True on success.
+            List of :obj:`~pyrogram.types.Photo` | :obj:`~pyrogram.types.Video`: On success, the list of bought photos and videos is returned.
         """
         return await self._client.send_payment_form(
             chat_id=self.chat.id,


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Modify the `send_payment_form` and `pay` methods to return a list of media objects instead of a boolean, reflecting the successful purchase of media. Extend the account TTL range in `set_account_ttl` to allow up to 730 days. Refactor text entity parsing in `send_media_group` for better code clarity. Update the Pyrogram version to 2.1.28.

New Features:
- Update the `send_payment_form` method to return a list of media objects (photos and videos) instead of a boolean, indicating the successful purchase of media items.

Enhancements:
- Extend the range of days for the `set_account_ttl` method from 30-548 to 30-730, allowing for a longer account time-to-live setting.
- Refactor the `send_media_group` method to use a utility function for parsing text entities, improving code readability and maintainability.

Chores:
- Bump the Pyrogram version from 2.1.27 to 2.1.28.

<!-- Generated by sourcery-ai[bot]: end summary -->